### PR TITLE
Fix CORS helper when origin header missing

### DIFF
--- a/api/apply-changes.js
+++ b/api/apply-changes.js
@@ -46,7 +46,9 @@ export default async function handler(req, res) {
 
   // --- CORS ヘッダー設定 ---
   function setCorsHeaders(res, origin) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
+    if (origin) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+    }
     res.setHeader('Access-Control-Allow-Credentials', 'true');
     res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
@@ -84,7 +86,11 @@ export default async function handler(req, res) {
     console.log('[apply-changes] Forbidden: origin not allowed');
     return res.status(403).json({ ok: false, error: 'Origin not allowed' });
   }
-  setCorsHeaders(res, origin);
+  if (origin) {
+    setCorsHeaders(res, origin);
+  } else {
+    setCorsHeaders(res);
+  }
 
   // リクエストボディ検証
   const { owner, repo, order, deletes } = req.body;

--- a/api/pages-status.js
+++ b/api/pages-status.js
@@ -37,7 +37,9 @@ function isOriginAllowed(origin, userOrigin) {
 
 // どのレスポンスにも付与する CORS ヘッダー
 function setCorsHeaders(res, origin) {
-  res.setHeader("Access-Control-Allow-Origin", origin);
+  if (origin) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
   res.setHeader("Access-Control-Allow-Credentials", "true");
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
@@ -62,7 +64,11 @@ export default async function handler(req, res) {
   }
 
   // 共通: CORS ヘッダーをまず付与
-  setCorsHeaders(res, origin);
+  if (origin) {
+    setCorsHeaders(res, origin);
+  } else {
+    setCorsHeaders(res);
+  }
 
   // 3) 認証チェック
   const auth = await getAuthenticatedUser(req);


### PR DESCRIPTION
## Summary
- avoid setting `Access-Control-Allow-Origin` when no `Origin` header is sent
- apply the same check to all endpoints using `setCorsHeaders`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68775ade8c60832f8147bdc794976862