### PR TITLE
Use Blob from formatted HTML when uploading

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -280,7 +280,8 @@ document.addEventListener("DOMContentLoaded", () => {
         try {
             // 1) FormData 組み立て
             const formData = new FormData();
-            formData.append("htmlFile", uploadHtml.files[0]);
+            const fixedBlob = new Blob([formattedOutput.textContent], { type: "text/html" });
+            formData.append("htmlFile", fixedBlob, "log.html");
             formData.append("owner", ownerName);
             formData.append("repo", repo);
             formData.append("path", path);


### PR DESCRIPTION
## Summary
- send formatted HTML as a Blob when committing to GitHub

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687789903d3c832fb95dce4efd8dbad9