### PR TITLE
Allow case-insensitive origin checks

### DIFF
--- a/api/apply-changes.js
+++ b/api/apply-changes.js
@@ -40,13 +40,13 @@ export default async function handler(req, res) {
   const APP_ORIGIN = process.env.APP_ORIGIN || 'https://ccfolialoguploader.com';
 
   function isOriginAllowed(origin, userOrigin) {
+    if (typeof origin !== 'string') return false;
+    const lcOrigin = origin.toLowerCase();
     const allowed =
-      typeof origin === 'string' &&
-      (
-        origin === APP_ORIGIN ||
-        (origin.endsWith('.github.io') &&
-          (origin === TEMPLATE_ORIGIN || origin === userOrigin))
-      );
+      lcOrigin === APP_ORIGIN.toLowerCase() ||
+      (lcOrigin.endsWith('.github.io') &&
+        (lcOrigin === TEMPLATE_ORIGIN.toLowerCase() ||
+          lcOrigin === userOrigin.toLowerCase()));
     console.log('[apply-changes] Origin check', { origin, userOrigin, allowed });
     return allowed;
   }
@@ -65,7 +65,7 @@ export default async function handler(req, res) {
   // --- OPTIONS（プリフライト） ---
   if (req.method === 'OPTIONS') {
     console.log('[apply-changes] Handling preflight OPTIONS');
-    if (origin && origin.endsWith('.github.io')) {
+    if (origin && origin.toLowerCase().endsWith('.github.io')) {
       setCorsHeaders(res, origin);
       return res.status(204).end();
     }

--- a/api/pages-status.js
+++ b/api/pages-status.js
@@ -31,10 +31,12 @@ const APP_ORIGIN = process.env.APP_ORIGIN || "https://ccfolialoguploader.com";
 // 既存の .github.io ドメインと APP_ORIGIN を許可
 function isOriginAllowed(origin, userOrigin) {
   if (typeof origin !== "string") return false;
-  if (origin === APP_ORIGIN) return true;
+  const lcOrigin = origin.toLowerCase();
   return (
-    origin.endsWith(".github.io") &&
-    (origin === process.env.TEMPLATE_ORIGIN || origin === userOrigin)
+    lcOrigin === APP_ORIGIN.toLowerCase() ||
+    (lcOrigin.endsWith(".github.io") &&
+      (lcOrigin === process.env.TEMPLATE_ORIGIN.toLowerCase() ||
+        lcOrigin === userOrigin.toLowerCase()))
   );
 }
 
@@ -53,7 +55,7 @@ export default async function handler(req, res) {
 
   // 1) プリフライト対応
   if (req.method === "OPTIONS") {
-    if (origin && origin.endsWith(".github.io")) {
+    if (origin && origin.toLowerCase().endsWith(".github.io")) {
       setCorsHeaders(res, origin);
       return res.status(204).end();
     }


### PR DESCRIPTION
## Summary
- relax origin checking in `apply-changes` and `pages-status`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68788102c2b8832f9da1b856366391f7