### PR TITLE
Fix owner case check

### DIFF
--- a/api/apply-changes.js
+++ b/api/apply-changes.js
@@ -112,7 +112,7 @@ export default async function handler(req, res) {
   }
 
   // オーナー一致チェック
-  if (owner !== username) {
+  if (owner.toLowerCase() !== username.toLowerCase()) {
     console.log('[apply-changes] Forbidden: owner mismatch', { owner, username });
     return res.status(403).json({ ok: false, error: 'Owner mismatch' });
   }

--- a/api/pages-status.js
+++ b/api/pages-status.js
@@ -95,7 +95,7 @@ export default async function handler(req, res) {
   }
 
   // 6) オーナー一致チェック
-  if (owner !== auth.username) {
+  if (owner.toLowerCase() !== auth.username.toLowerCase()) {
     return res.status(403).json({ ok: false, error: "Owner mismatch" });
   }
 


### PR DESCRIPTION
## Summary
- allow case-insensitive username checks for API routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878831804b0832fa7a0d3366cb2f2e6