### PR TITLE
Add reload script for formatted HTML

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -270,8 +270,9 @@ document.addEventListener("DOMContentLoaded", () => {
             const fontStyle =
                 '<style>* { font-family: sans-serif !important; }</style>';
             const norobotScript = '<script src="norobot.js"></scr' + 'ipt>';
+            const reloadScript = '<script>if (!window.location.href.includes("forceReloaded")) { const sep = window.location.href.includes("?") ? "&" : "?"; window.location.href = window.location.href + sep + "forceReloaded=1"; }</script>';
             html = html.replace(/<\/head>/i, robotsMeta + "\n" + fontStyle + "\n" +
-                norobotScript + "\n</head>");
+                norobotScript + "\n" + reloadScript + "\n</head>");
             formattedOutput.textContent = html;
         };
         reader.readAsText(uploadHtml.files[0]);


### PR DESCRIPTION
## Summary
- ensure formatted HTML auto-reloads once by injecting `reloadScript`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f5f641084832fa0fc6e409f60cfd4